### PR TITLE
Admin return button

### DIFF
--- a/src/view/admin/view/career/components/CareerForm.tsx
+++ b/src/view/admin/view/career/components/CareerForm.tsx
@@ -6,6 +6,7 @@ import { AdminInput } from '../../employee/components/help_html/AdminInput'
 import styled from 'styled-components'
 import CodicAPIService from 'shared/api/services/CodicAPIService'
 import Validations from 'shared/validations/Validations'
+import { FormReturnButton } from '../../employee/components/help_html/FormReturnButton'
 
 export const CareerForm = (props: { setChoice: (arg0: number) => void; chosenRowData: any; method: 'create' | 'update' }) => {
 	// AdminId is needed for check in backend
@@ -61,6 +62,7 @@ export const CareerForm = (props: { setChoice: (arg0: number) => void; chosenRow
 
 	return (
 		<Wrapper>
+			<FormReturnButton setChoice={props.setChoice} />
 			{isCreate() ? <h2>Lägg till ny jobbannons</h2> : <h2>Uppdatera jobbannons</h2>}
 			<Formik
 				initialValues={initialValues}

--- a/src/view/admin/view/employee/components/EmployeeForm.tsx
+++ b/src/view/admin/view/employee/components/EmployeeForm.tsx
@@ -3,10 +3,11 @@ import { useContext } from 'react'
 import { UserContext } from 'shared/providers/UserProvider'
 import { Button } from 'components/html/Button'
 import { AdminInput } from './help_html/AdminInput'
+import { FormReturnButton } from '../../employee/components/help_html/FormReturnButton'
 import styled from 'styled-components'
 import CodicAPIService from 'shared/api/services/CodicAPIService'
 
-export const EmployeeForm = (props: { setChoice: (arg0: number) => void , chosenRowData: { _id?: any; username: any; email: any; personalDetails: { firstName: any; lastName: any; phone: any }; employeeInformation: { workPhone: any; workEmail: any; startEmployeeDate: any; lastEmployeeDate: any; isEmploymentActive: any } } }) => {
+export const EmployeeForm = (props: { setChoice: (arg0: number) => void, chosenRowData: { _id?: any; username: any; email: any; personalDetails: { firstName: any; lastName: any; phone: any }; employeeInformation: { workPhone: any; workEmail: any; startEmployeeDate: any; lastEmployeeDate: any; isEmploymentActive: any } } }) => {
 	// AdminId is needed for check in backend
 	const [authenticatedUser, setAuthenticatedUser] = useContext(UserContext)
 	const adminId = authenticatedUser._id
@@ -15,17 +16,17 @@ export const EmployeeForm = (props: { setChoice: (arg0: number) => void , chosen
 		employeeInformation: {
 			workPhone: props.chosenRowData.employeeInformation ? props.chosenRowData.employeeInformation.workPhone : '',
 			workEmail: props.chosenRowData.employeeInformation ? props.chosenRowData.employeeInformation.workEmail : '',
-			startEmployeeDate:  props.chosenRowData.employeeInformation ? props.chosenRowData.employeeInformation.startEmployeeDate : '',
-			lastEmployeeDate:  props.chosenRowData.employeeInformation ? props.chosenRowData.employeeInformation.lastEmployeeDate : '',
+			startEmployeeDate: props.chosenRowData.employeeInformation ? props.chosenRowData.employeeInformation.startEmployeeDate : '',
+			lastEmployeeDate: props.chosenRowData.employeeInformation ? props.chosenRowData.employeeInformation.lastEmployeeDate : '',
 			isEmploymentActive: props.chosenRowData.employeeInformation ? props.chosenRowData.employeeInformation.isEmploymentActive : false,
 		},
 	}
 
-	const updateEmployeeInformationInDB = async (values:any) => {
+	const updateEmployeeInformationInDB = async (values: any) => {
 		const userId = props.chosenRowData._id
 
 		const updatedEmployeeInformation = {
-			'employeeInformation' : {
+			'employeeInformation': {
 				'workPhone': values.employeeInformation.workPhone,
 				'workEmail': values.employeeInformation.workEmail,
 				'startEmployeeDate': new Date(values.employeeInformation.startEmployeeDate),
@@ -38,46 +39,51 @@ export const EmployeeForm = (props: { setChoice: (arg0: number) => void , chosen
 		try {
 			await CodicAPIService.updateEmployeeInformation(userId, updatedEmployeeInformation)
 			props.setChoice(0)
-				
+
 		} catch (error) {
 			console.log(error)
 		}
 	}
 
-	return(
+	return (
 		<Wrapper>
-			<h2>Lägg till / Ändra anställningsinformation</h2>
-			<Formik
-				initialValues = {initialValues}
-				/*validationSchema = {}*/
-				onSubmit = {updateEmployeeInformationInDB} 
-			>
-				<Form autoComplete='off'>
-					<EmployeeInfoWrapper>
-						<h3>Information om den anställde: </h3>
-						<Div>
-							Användarnamn: {props.chosenRowData.username}<br />
-							Förnamn: {props.chosenRowData.personalDetails.firstName}<br />
-							Efternamn: {props.chosenRowData.personalDetails.lastName}<br />
-							Telefon, privat: {props.chosenRowData.personalDetails.phone}<br />
-							E-post, privat: {props.chosenRowData.email}<br />
-							<br />
-							<hr />
-						</Div>
-						<AdminInput name='employeeInformation.workPhone' label='Telefon, arbete' />
-						<AdminInput name='employeeInformation.workEmail' label='E-post, arbete' type='email'/>
-					</EmployeeInfoWrapper>
-					<EmploymentInfoWrapper>
-						<h3>Information om anställningen: </h3>
-						<AdminInput name='employeeInformation.startEmployeeDate' label='Startdatum för anställning' type='date'/>
-						<AdminInput name='employeeInformation.lastEmployeeDate' label='Slutdatum för anställning' type='date' />
-						<AdminInput name='employeeInformation.isEmploymentActive' label='Pågående anställning' type='checkbox'/>
-					</EmploymentInfoWrapper>
-					<br />
-					<Button text={'Spara'} />
-					<br />
-				</Form>
-			</Formik>
+			<Div>
+				<FormReturnButton setChoice={props.setChoice} />
+				<h2>Lägg till / Ändra anställningsinformation</h2>
+			</Div>
+			<Div>
+				<Formik
+					initialValues={initialValues}
+					/*validationSchema = {}*/
+					onSubmit={updateEmployeeInformationInDB}
+				>
+					<Form autoComplete='off'>
+						<EmployeeInfoWrapper>
+							<h3>Information om den anställde: </h3>
+							<Content>
+								Användarnamn: {props.chosenRowData.username}<br />
+								Förnamn: {props.chosenRowData.personalDetails.firstName}<br />
+								Efternamn: {props.chosenRowData.personalDetails.lastName}<br />
+								Telefon, privat: {props.chosenRowData.personalDetails.phone}<br />
+								E-post, privat: {props.chosenRowData.email}<br />
+								<br />
+								<hr />
+							</Content>
+							<AdminInput name='employeeInformation.workPhone' label='Telefon, arbete' />
+							<AdminInput name='employeeInformation.workEmail' label='E-post, arbete' type='email' />
+						</EmployeeInfoWrapper>
+						<EmploymentInfoWrapper>
+							<h3>Information om anställningen: </h3>
+							<AdminInput name='employeeInformation.startEmployeeDate' label='Startdatum för anställning' type='date' />
+							<AdminInput name='employeeInformation.lastEmployeeDate' label='Slutdatum för anställning' type='date' />
+							<AdminInput name='employeeInformation.isEmploymentActive' label='Pågående anställning' type='checkbox' />
+						</EmploymentInfoWrapper>
+						<br />
+						<Button text={'Spara'} />
+						<br />
+					</Form>
+				</Formik>
+			</Div>
 		</Wrapper>
 	)
 }
@@ -95,6 +101,10 @@ const Wrapper = styled.div`
 `
 
 const Div = styled.div`
+	padding: 5px 10px 10px 10px;
+`
+
+const Content = styled.div`
 	padding: 5px 10px 10px 10px;
 `
 

--- a/src/view/admin/view/employee/components/help_html/FormReturnButton.tsx
+++ b/src/view/admin/view/employee/components/help_html/FormReturnButton.tsx
@@ -1,0 +1,10 @@
+import { Button } from 'components/html/Button'
+
+export const FormReturnButton = (props: { setChoice: (arg0: number) => void }) => {
+
+	return (
+		<>
+			<Button text='Åter till Listan' onClick={() => props.setChoice(0)} />
+		</>
+	)
+}

--- a/src/view/admin/view/user/components/RoleForm.tsx
+++ b/src/view/admin/view/user/components/RoleForm.tsx
@@ -3,9 +3,9 @@ import { useContext } from 'react'
 import { UserContext } from 'shared/providers/UserProvider'
 import { Button } from 'components/html/Button'
 import { AdminSelect } from '../../employee/components/help_html/AdminSelect'
+import { FormReturnButton } from '../../employee/components/help_html/FormReturnButton'
 import styled from 'styled-components'
 import CodicAPIService from 'shared/api/services/CodicAPIService'
-
 
 export const RoleForm = (props: { setChoice: (arg0: number) => void, chosenRowData: { _id?: any; username: string; email: string; role: string; personalDetails: { firstName: string; lastName: string; phone: string }; } }) => {
 	const [authenticatedUser, setAuthenticatedUser] = useContext(UserContext)
@@ -23,7 +23,7 @@ export const RoleForm = (props: { setChoice: (arg0: number) => void, chosenRowDa
 			'role': values.role,
 			'id': adminId
 		}
-		
+
 		try {
 			await CodicAPIService.updateUserRole(userId, reqBody)
 			props.setChoice(0)
@@ -35,6 +35,7 @@ export const RoleForm = (props: { setChoice: (arg0: number) => void, chosenRowDa
 
 	return (
 		<Wrapper>
+			<FormReturnButton setChoice={props.setChoice} />
 			<h2>Ändra användares behörighet</h2>
 			<Formik
 				initialValues={initialValues}


### PR DESCRIPTION
I CareerForm, RoleForm och EmployeeForm har jag lagt till en ny komponent som gör att man kan återvända till listan utan att skicka iväg formuläret (göra ett API-anrop). Eftersom både lista och formulär har samma url så leder bakåt-knappen i browsern endast till Admin-startsidan.